### PR TITLE
Add DocFX documentation and deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,37 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install DocFX
+        run: dotnet tool install -g docfx
+
+      - name: Generate Documentation
+        run: docfx docs/docfx.json
+
+      - name: Upload Documentation Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: documentation
+          path: docs/_site
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_site

--- a/README.md
+++ b/README.md
@@ -24,3 +24,32 @@ By leveraging Selenium WebDriver, the application can interact with web pages an
 - [Selenium WebDriver](https://www.selenium.dev/) (ChromeDriver)
 - [ExcelDataReader](https://github.com/ExcelDataReader/ExcelDataReader) library for reading Excel files.
 - Google Chrome browser installed.
+
+## Documentation
+
+### Generating Documentation
+
+To generate the technical documentation for the project, follow these steps:
+
+1. Install [DocFX](https://dotnet.github.io/docfx/):
+   ```sh
+   choco install docfx -y
+   ```
+
+2. Navigate to the `docs` directory:
+   ```sh
+   cd docs
+   ```
+
+3. Run DocFX to generate the documentation:
+   ```sh
+   docfx
+   ```
+
+The generated documentation will be available in the `_site` directory.
+
+### Accessing Documentation
+
+The documentation is hosted on GitHub Pages and can be accessed at the following URL:
+
+[https://devopsvisions.github.io/wordpress-automation-toolkit/](https://devopsvisions.github.io/wordpress-automation-toolkit/)

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,19 @@
+# Ignore DocFX output directory
+_site/
+
+# Ignore temporary files
+*.tmp
+*.log
+*.bak
+*.swp
+*.swo
+*.DS_Store
+*.idea/
+*.vscode/
+*.vs/
+*.user
+*.userosscache
+*.suo
+*.sln.docstates
+*.userprefs
+mono_crash.*

--- a/docs/articles/configuration.md
+++ b/docs/articles/configuration.md
@@ -1,0 +1,49 @@
+# Configuration
+
+This section provides details on configuring the WordPress Learning Automation Toolkit.
+
+## Configuration Options
+
+The following configuration options are available:
+
+### Platform Settings
+
+- **LoginUrl**: The URL for the admin login page.
+- **AddNewUserUrl**: The URL for adding new users.
+- **Admin1UserNameOrEmail**: The username or email of the first admin.
+- **Admin2UserNameOrEmail**: The username or email of the second admin.
+- **PreRegisterRole**: The role assigned to users before registration.
+- **PostRegisterRole**: The role assigned to users after registration.
+
+### Data Columns
+
+- **UserNameColumn**: The column name for the username in the Excel file.
+- **EmailColumn**: The column name for the email in the Excel file.
+- **MembershipColumn**: The column name for the membership level in the Excel file.
+- **ColumnNames**: A comma-separated list of column names in the Excel file.
+
+## Usage
+
+To configure the application, update the `App.config` file with the appropriate values for your environment. Here is an example configuration:
+
+```xml
+<configuration>
+  <appSettings>
+    <!-- Platform Settings -->
+    <add key="LoginUrl" value="https://example.com/admin"/>
+    <add key="AddNewUserUrl" value="https://example.com/wp-admin/user-new.php"/>
+    <add key="Admin1UserNameOrEmail" value="Admin1UserNameOrEmail"/>
+    <add key="Admin2UserNameOrEmail" value="Admin2UserNameOrEmail"/>
+    <add key="PreRegisterRole" value="pre_register"/>
+    <add key="PostRegisterRole" value="member"/>
+
+    <!-- Data Columns -->
+    <add key="UserNameColumn" value="Username" />
+    <add key="EmailColumn" value="Email" />
+    <add key="MembershipColumn" value="Membership" />
+    <add key="ColumnNames" value="Username,Email,Membership" />
+  </appSettings>
+</configuration>
+```
+
+Update the values as needed to match your environment and requirements.

--- a/docs/articles/deployment.md
+++ b/docs/articles/deployment.md
@@ -1,0 +1,118 @@
+# Deployment
+
+This section provides instructions for deploying the WordPress Learning Automation Toolkit to different environments, such as local, staging, and production.
+
+## Local Deployment
+
+To deploy the application locally, follow these steps:
+
+1. Clone the repository:
+
+   ```sh
+   git clone https://github.com/DevOpsVisions/wordpress-automation-toolkit.git
+   cd wordpress-automation-toolkit
+   ```
+
+2. Restore the .NET Core dependencies:
+
+   ```sh
+   dotnet restore
+   ```
+
+3. Build the project:
+
+   ```sh
+   dotnet build
+   ```
+
+4. Run the application:
+
+   ```sh
+   dotnet run
+   ```
+
+## Staging Deployment
+
+To deploy the application to a staging environment, follow these steps:
+
+1. Set up a staging server with the necessary prerequisites, such as .NET Core SDK and Google Chrome browser.
+
+2. Clone the repository to the staging server:
+
+   ```sh
+   git clone https://github.com/DevOpsVisions/wordpress-automation-toolkit.git
+   cd wordpress-automation-toolkit
+   ```
+
+3. Restore the .NET Core dependencies:
+
+   ```sh
+   dotnet restore
+   ```
+
+4. Build the project:
+
+   ```sh
+   dotnet build
+   ```
+
+5. Run the application:
+
+   ```sh
+   dotnet run
+   ```
+
+## Production Deployment
+
+To deploy the application to a production environment, follow these steps:
+
+1. Set up a production server with the necessary prerequisites, such as .NET Core SDK and Google Chrome browser.
+
+2. Clone the repository to the production server:
+
+   ```sh
+   git clone https://github.com/DevOpsVisions/wordpress-automation-toolkit.git
+   cd wordpress-automation-toolkit
+   ```
+
+3. Restore the .NET Core dependencies:
+
+   ```sh
+   dotnet restore
+   ```
+
+4. Build the project:
+
+   ```sh
+   dotnet build
+   ```
+
+5. Run the application:
+
+   ```sh
+   dotnet run
+   ```
+
+## GitHub Pages Deployment
+
+To deploy the documentation to GitHub Pages, follow these steps:
+
+1. Ensure that the `docfx.json` file is properly configured for generating the documentation.
+
+2. Generate the documentation using DocFX:
+
+   ```sh
+   docfx
+   ```
+
+3. Commit the generated documentation to the `gh-pages` branch:
+
+   ```sh
+   git checkout gh-pages
+   cp -r _site/* .
+   git add .
+   git commit -m "Update documentation"
+   git push origin gh-pages
+   ```
+
+4. Access the documentation on GitHub Pages using the provided URL.

--- a/docs/articles/faq.md
+++ b/docs/articles/faq.md
@@ -1,0 +1,100 @@
+# Frequently Asked Questions (FAQ)
+
+## General Questions
+
+### What is the WordPress Learning Automation Toolkit?
+
+The WordPress Learning Automation Toolkit is a .NET Core application designed to automate various tasks using Selenium WebDriver and other services. It includes services for configuration management, file path handling, authentication, password management, web driver operations, Excel reading, and user management.
+
+### What are the main features of the toolkit?
+
+The main features of the toolkit include:
+- Adding Users: Automates the process of adding new users to the platform.
+- Removing Users: Automates the process of deleting users from the platform.
+- Membership Updates: Automates the process of updating user memberships.
+- Reads User Data: Extracts user information, such as username and email, directly from an Excel file, streamlining the registration process.
+- Secure Password Handling: Ensures that passwords are handled securely during the registration process, protecting sensitive user information.
+- Flexible File Path Support: Supports both default and custom file paths for the Excel file, allowing users to easily manage and update user data sources.
+
+## Installation and Setup
+
+### What are the prerequisites for using the toolkit?
+
+Before you begin, ensure you have the following installed:
+- [.NET Core SDK](https://dotnet.microsoft.com/download)
+- [Selenium WebDriver](https://www.selenium.dev/) (ChromeDriver)
+- [ExcelDataReader](https://github.com/ExcelDataReader/ExcelDataReader) library for reading Excel files.
+- Google Chrome browser installed.
+
+### How do I install the toolkit?
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/DevOpsVisions/wordpress-automation-toolkit.git
+   cd wordpress-automation-toolkit
+   ```
+
+2. Restore the .NET Core dependencies:
+   ```sh
+   dotnet restore
+   ```
+
+3. Build the project:
+   ```sh
+   dotnet build
+   ```
+
+## Usage
+
+### How do I add users using the toolkit?
+
+1. Prepare an Excel file with user data, including columns for username, email, and membership level.
+2. Run the application and select the "Register Users" option from the menu.
+3. Provide the file path to the Excel file, admin username, admin password, and registration password.
+4. The application will read the user data from the Excel file and add the users to the platform.
+
+### How do I update user memberships using the toolkit?
+
+1. Prepare an Excel file with user data, including columns for username, email, and membership level.
+2. Run the application and select the "Update Users" option from the menu.
+3. Provide the file path to the Excel file, admin username, and admin password.
+4. The application will read the user data from the Excel file and update the membership levels for the users on the platform.
+
+### How do I remove users using the toolkit?
+
+1. Prepare an Excel file with user data, including columns for username and email.
+2. Run the application and select the "Remove Users" option from the menu.
+3. Provide the file path to the Excel file, admin username, and admin password.
+4. The application will read the user data from the Excel file and remove the users from the platform.
+
+## Troubleshooting
+
+### What should I do if the application fails to log in to the admin panel?
+
+1. Verify that the login URL is correct in the `App.config` file.
+2. Ensure that the admin username and password are correct.
+3. Check if the website is accessible and not down for maintenance.
+
+### What should I do if the user registration fails?
+
+1. Ensure that the `AddNewUserUrl` is correct in the `App.config` file.
+2. Verify that the user data in the Excel file is correct and complete.
+3. Check if the registration password is correct.
+
+### What should I do if the membership update fails?
+
+1. Verify that the membership level dropdown is correctly identified in the code.
+2. Ensure that the membership levels in the Excel file match the options available on the website.
+3. Check if the user exists on the platform before attempting to update the membership.
+
+### What should I do if the application cannot find the specified Excel file?
+
+1. Ensure that the file path provided is correct.
+2. Verify that the file exists and is accessible.
+3. Check if the file extension is correct (e.g., `.xlsx`).
+
+### What should I do if the application encounters WebDriver errors?
+
+1. Ensure that the ChromeDriver is installed and its path is correctly set.
+2. Verify that the Google Chrome browser is installed and up to date.
+3. Check if the WebDriver version is compatible with the installed Chrome version.

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -1,0 +1,56 @@
+# Getting Started
+
+This guide will help you set up and use the WordPress Learning Automation Toolkit.
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+
+- [.NET Core SDK](https://dotnet.microsoft.com/download)
+- [Selenium WebDriver](https://www.selenium.dev/) (ChromeDriver)
+- [ExcelDataReader](https://github.com/ExcelDataReader/ExcelDataReader) library for reading Excel files.
+- Google Chrome browser installed.
+
+## Installation
+
+1. Clone the repository:
+
+   ```sh
+   git clone https://github.com/DevOpsVisions/wordpress-automation-toolkit.git
+   cd wordpress-automation-toolkit
+   ```
+
+2. Restore the .NET Core dependencies:
+
+   ```sh
+   dotnet restore
+   ```
+
+3. Build the project:
+
+   ```sh
+   dotnet build
+   ```
+
+## Usage
+
+### Adding Users
+
+1. Prepare an Excel file with user data, including columns for username, email, and membership level.
+2. Run the application and select the "Register Users" option from the menu.
+3. Provide the file path to the Excel file, admin username, admin password, and registration password.
+4. The application will read the user data from the Excel file and add the users to the platform.
+
+### Updating Memberships
+
+1. Prepare an Excel file with user data, including columns for username, email, and membership level.
+2. Run the application and select the "Update Users" option from the menu.
+3. Provide the file path to the Excel file, admin username, and admin password.
+4. The application will read the user data from the Excel file and update the membership levels for the users on the platform.
+
+### Removing Users
+
+1. Prepare an Excel file with user data, including columns for username and email.
+2. Run the application and select the "Remove Users" option from the menu.
+3. Provide the file path to the Excel file, admin username, and admin password.
+4. The application will read the user data from the Excel file and remove the users from the platform.

--- a/docs/articles/overview.md
+++ b/docs/articles/overview.md
@@ -1,0 +1,41 @@
+# Project Overview
+
+The WordPress Learning Automation Toolkit is a .NET Core application designed to automate various tasks using Selenium WebDriver and other services. The project includes services for configuration management, file path handling, authentication, password management, web driver operations, Excel reading, and user management.
+
+## Main Features
+
+- **Adding Users:** Automates the process of adding new users to the platform.
+- **Removing Users:** Automates the process of deleting users from the platform.
+- **Membership Updates:** Automates the process of updating user memberships.
+- **Reads User Data:** Extracts user information, such as username and email, directly from an Excel file, streamlining the registration process.
+- **Secure Password Handling:** Ensures that passwords are handled securely during the registration process, protecting sensitive user information.
+- **Flexible File Path Support:** Supports both default and custom file paths for the Excel file, allowing users to easily manage and update user data sources.
+
+## Examples and Use Cases
+
+### Example 1: Adding Users
+
+The following example demonstrates how to add users to the platform using the WordPress Learning Automation Toolkit:
+
+1. Prepare an Excel file with user data, including columns for username, email, and membership level.
+2. Run the application and select the "Register Users" option from the menu.
+3. Provide the file path to the Excel file, admin username, admin password, and registration password.
+4. The application will read the user data from the Excel file and add the users to the platform.
+
+### Example 2: Updating Memberships
+
+The following example demonstrates how to update user memberships using the WordPress Learning Automation Toolkit:
+
+1. Prepare an Excel file with user data, including columns for username, email, and membership level.
+2. Run the application and select the "Update Users" option from the menu.
+3. Provide the file path to the Excel file, admin username, and admin password.
+4. The application will read the user data from the Excel file and update the membership levels for the users on the platform.
+
+### Example 3: Removing Users
+
+The following example demonstrates how to remove users from the platform using the WordPress Learning Automation Toolkit:
+
+1. Prepare an Excel file with user data, including columns for username and email.
+2. Run the application and select the "Remove Users" option from the menu.
+3. Provide the file path to the Excel file, admin username, and admin password.
+4. The application will read the user data from the Excel file and remove the users from the platform.

--- a/docs/articles/troubleshooting.md
+++ b/docs/articles/troubleshooting.md
@@ -1,0 +1,57 @@
+# Troubleshooting
+
+This section provides solutions to common issues and errors that you may encounter while using the WordPress Learning Automation Toolkit.
+
+## Common Issues
+
+### Issue 1: Unable to Login
+
+**Description:** The application fails to log in to the admin panel.
+
+**Solution:**
+1. Verify that the login URL is correct in the `App.config` file.
+2. Ensure that the admin username and password are correct.
+3. Check if the website is accessible and not down for maintenance.
+
+### Issue 2: User Registration Fails
+
+**Description:** The application fails to register new users.
+
+**Solution:**
+1. Ensure that the `AddNewUserUrl` is correct in the `App.config` file.
+2. Verify that the user data in the Excel file is correct and complete.
+3. Check if the registration password is correct.
+
+### Issue 3: Membership Update Fails
+
+**Description:** The application fails to update user memberships.
+
+**Solution:**
+1. Verify that the membership level dropdown is correctly identified in the code.
+2. Ensure that the membership levels in the Excel file match the options available on the website.
+3. Check if the user exists on the platform before attempting to update the membership.
+
+### Issue 4: Excel File Not Found
+
+**Description:** The application cannot find the specified Excel file.
+
+**Solution:**
+1. Ensure that the file path provided is correct.
+2. Verify that the file exists and is accessible.
+3. Check if the file extension is correct (e.g., `.xlsx`).
+
+### Issue 5: WebDriver Errors
+
+**Description:** The application encounters errors related to the WebDriver.
+
+**Solution:**
+1. Ensure that the ChromeDriver is installed and its path is correctly set.
+2. Verify that the Google Chrome browser is installed and up to date.
+3. Check if the WebDriver version is compatible with the installed Chrome version.
+
+## Tips for Resolving Problems
+
+- Always check the application logs for detailed error messages.
+- Ensure that all dependencies are installed and up to date.
+- Verify the configuration settings in the `App.config` file.
+- If the issue persists, consider searching for solutions online or reaching out to the community for help.

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,0 +1,56 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "src/**/*.cs"
+          ],
+          "exclude": [
+            "**/bin/**",
+            "**/obj/**"
+          ]
+        }
+      ],
+      "dest": "api",
+      "properties": {
+        "TargetFramework": "net8.0"
+      }
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "articles/**.md",
+          "toc.yml",
+          "*.md"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "styles/**",
+          "images/**"
+        ]
+      }
+    ],
+    "overwrite": [
+      {
+        "files": [
+          "apidoc/**.md"
+        ]
+      }
+    ],
+    "dest": "_site",
+    "globalMetadata": {
+      "_appTitle": "WordPress Learning Automation Toolkit",
+      "_appFooter": "© 2023 DevOpsVisions"
+    },
+    "template": [
+      "default",
+      "templates/custom"
+    ]
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,24 @@
+# WordPress Learning Automation Toolkit Documentation
+
+Welcome to the WordPress Learning Automation Toolkit documentation. This site provides comprehensive information about the project, including its features, setup instructions, configuration options, and more.
+
+## Overview
+
+The WordPress Learning Automation Toolkit is a .NET Core application designed to automate various tasks using Selenium WebDriver and other services. The project includes services for configuration management, file path handling, authentication, password management, web driver operations, Excel reading, and user management.
+
+## Sections
+
+- [Overview](articles/overview.md)
+- [Getting Started](articles/getting-started.md)
+- [Configuration](articles/configuration.md)
+- [Deployment](articles/deployment.md)
+- [Troubleshooting](articles/troubleshooting.md)
+- [FAQ](articles/faq.md)
+
+## Contributing
+
+We welcome contributions to improve this documentation. If you find any issues or have suggestions, please open an issue or submit a pull request on GitHub.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](../LICENSE) file for more details.

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -1,0 +1,54 @@
+/* Custom styles for the WordPress Learning Automation Toolkit documentation */
+
+/* Header styles */
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Arial', sans-serif;
+    color: #333;
+}
+
+/* Link styles */
+a {
+    color: #007bff;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* Code block styles */
+pre {
+    background-color: #f8f9fa;
+    border: 1px solid #e1e1e1;
+    padding: 10px;
+    border-radius: 5px;
+}
+
+/* Table styles */
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    border: 1px solid #e1e1e1;
+    padding: 8px;
+    text-align: left;
+}
+
+th {
+    background-color: #f1f1f1;
+}
+
+/* List styles */
+ul, ol {
+    margin-left: 20px;
+}
+
+/* Blockquote styles */
+blockquote {
+    border-left: 5px solid #007bff;
+    padding-left: 10px;
+    color: #555;
+    font-style: italic;
+}

--- a/docs/templates/custom.html
+++ b/docs/templates/custom.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{_appTitle}}</title>
+    <link rel="stylesheet" href="{{basePath}}styles/custom.css">
+</head>
+<body>
+    <header>
+        <h1>{{_appTitle}}</h1>
+    </header>
+    <nav>
+        <ul>
+            <li><a href="{{basePath}}index.html">Home</a></li>
+            <li><a href="{{basePath}}articles/overview.html">Overview</a></li>
+            <li><a href="{{basePath}}articles/getting-started.html">Getting Started</a></li>
+            <li><a href="{{basePath}}articles/configuration.html">Configuration</a></li>
+            <li><a href="{{basePath}}articles/deployment.html">Deployment</a></li>
+            <li><a href="{{basePath}}articles/troubleshooting.html">Troubleshooting</a></li>
+            <li><a href="{{basePath}}articles/faq.html">FAQ</a></li>
+        </ul>
+    </nav>
+    <main>
+        {{> content}}
+    </main>
+    <footer>
+        <p>{{_appFooter}}</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
Fixes #14

Add technical documentation generation and deployment using DocFX and GitHub Pages.

- **DocFX Configuration:**
  - Add `docfx.json` to configure DocFX for generating documentation.
  - Include metadata, source code directories, and output directory.

- **Documentation Content:**
  - Add `index.md` as the main landing page.
  - Add `overview.md`, `getting-started.md`, `configuration.md`, `deployment.md`, `troubleshooting.md`, and `faq.md` for detailed documentation sections.

- **Customization:**
  - Add `custom.css` for custom styles.
  - Add `custom.html` for custom layout.

- **GitHub Pages Deployment:**
  - Add `.github/workflows/deploy-docs.yml` to automate documentation deployment to GitHub Pages using GitHub Actions.

- **README Update:**
  - Update `README.md` to include instructions for generating and accessing the documentation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DevOpsVisions/wordpress-automation-toolkit/issues/14?shareId=79498626-d703-4c27-a5df-404aa060efe5).