### PR TITLE
Refactor - Admin Login - Get Admin User Name

### DIFF
--- a/src/app/Dovs.WordPressAutoKit/App.config
+++ b/src/app/Dovs.WordPressAutoKit/App.config
@@ -5,8 +5,7 @@
     <!-- Platform Settings -->
     <add key="LoginUrl" value="https://example.com/admin"/>
     <add key="AddNewUserUrl" value="https://example.com/wp-admin/user-new.php"/>
-    <add key="Admin1UserNameOrEmail" value="Admin1UserNameOrEmail"/>
-    <add key="Admin2UserNameOrEmail" value="Admin2UserNameOrEmail"/>
+    <add key="AdminUserNames" value="Admin1,Admin2"/>
     <add key="PreRegisterRole" value="pre_register"/>
     <add key="PostRegisterRole" value="member"/>
 

--- a/src/app/Dovs.WordPressAutoKit/Dovs.WordPressAutoKit.csproj
+++ b/src/app/Dovs.WordPressAutoKit/Dovs.WordPressAutoKit.csproj
@@ -14,6 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dovs.CommonComponents" Version="1.0.0" />
+    <PackageReference Include="Dovs.FileSystemInteractor" Version="1.0.0" />
     <PackageReference Include="ExcelDataReader" Version="3.7.0" />
     <PackageReference Include="Selenium.Support" Version="4.23.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />

--- a/src/app/Dovs.WordPressAutoKit/Interfaces/IAuthenticationService.cs
+++ b/src/app/Dovs.WordPressAutoKit/Interfaces/IAuthenticationService.cs
@@ -9,6 +9,6 @@
         /// Gets the admin username for login.
         /// </summary>
         /// <returns>The admin username.</returns>
-        string GetAdminUsername(string Admin1UserNameOrEmail, string Admin2UserNameOrEmail);
+        string GetAdminUsername(string adminUserNames);
     }
 }

--- a/src/app/Dovs.WordPressAutoKit/Program.cs
+++ b/src/app/Dovs.WordPressAutoKit/Program.cs
@@ -156,10 +156,9 @@ class Program
 
     private static string GetAdminUsername()
     {
-        string Admin1UserNameOrEmail = configurationService.GetConfigValue("Admin1UserNameOrEmail");
-        string Admin2UserNameOrEmail = configurationService.GetConfigValue("Admin2UserNameOrEmail");
+        string adminUserNames = configurationService.GetConfigValue("AdminUserNames");
 
-        return authenticationService.GetAdminUsername(Admin1UserNameOrEmail, Admin2UserNameOrEmail);
+        return authenticationService.GetAdminUsername(adminUserNames);
     }
 
     private static (string FilePath, string AdminUsername, string AdminPassword, string RegistrationPassword)? ParseArguments(string[] args)

--- a/src/app/Dovs.WordPressAutoKit/Services/AdminLoginService.cs
+++ b/src/app/Dovs.WordPressAutoKit/Services/AdminLoginService.cs
@@ -1,7 +1,4 @@
-
 using Dovs.WordPressAutoKit.Interfaces;
-using Dovs.FileSystemInteractor.Interfaces;
-using Dovs.FileSystemInteractor.Services;
 using OpenQA.Selenium;
 using Dovs.WordPressAutoKit.Common;
 

--- a/src/app/Dovs.WordPressAutoKit/Services/AuthenticationService.cs
+++ b/src/app/Dovs.WordPressAutoKit/Services/AuthenticationService.cs
@@ -1,8 +1,4 @@
-﻿
-using System;
-using Dovs.WordPressAutoKit.Interfaces;
-using Dovs.FileSystemInteractor.Interfaces;
-using Dovs.FileSystemInteractor.Services;
+﻿using Dovs.WordPressAutoKit.Interfaces;
 
 namespace Dovs.WordPressAutoKit.Services
 {
@@ -14,24 +10,40 @@ namespace Dovs.WordPressAutoKit.Services
         /// <summary>  
         /// Gets the admin username for login.  
         /// </summary>  
+        /// <param name="adminUserNames">Comma-separated admin usernames.</param>
         /// <returns>The admin username.</returns>  
-        public string GetAdminUsername(string Admin1UserNameOrEmail, string Admin2UserNameOrEmail)
+        public string GetAdminUsername(string adminUserNames)
         {
-            Console.WriteLine($"Choose a username to login as admin: \n1. {Admin1UserNameOrEmail}\n2. {Admin2UserNameOrEmail}\n3. Other");
-            string choice = Console.ReadLine();
+            var usernames = adminUserNames.Split(',');
 
-            switch (choice)
+            if (usernames.Length < 2)
             {
-                case "1":
-                    return Admin1UserNameOrEmail;
-                case "2":
-                    return Admin2UserNameOrEmail;
-                case "3":
+                throw new ArgumentException("Please provide at least two admin usernames separated by a comma.");
+            }
+
+            Console.WriteLine("Choose a username to login as admin:");
+            for (int i = 0; i < usernames.Length; i++)
+            {
+                Console.WriteLine($"{i + 1}. {usernames[i].Trim()}");
+            }
+            Console.WriteLine($"{usernames.Length + 1}. Other");
+
+            string choice = Console.ReadLine();
+            int choiceNumber;
+            if (int.TryParse(choice, out choiceNumber))
+            {
+                if (choiceNumber >= 1 && choiceNumber <= usernames.Length)
+                {
+                    return usernames[choiceNumber - 1].Trim();
+                }
+                else if (choiceNumber == usernames.Length + 1)
+                {
                     Console.WriteLine("Enter your username:");
                     return Console.ReadLine();
-                default:
-                    return null;
+                }
             }
+
+            return null;
         }
     }
 }

--- a/src/app/Dovs.WordPressAutoKit/Services/PasswordService.cs
+++ b/src/app/Dovs.WordPressAutoKit/Services/PasswordService.cs
@@ -1,5 +1,5 @@
 ﻿using Dovs.WordPressAutoKit.Interfaces;
-using System;
+
 
 namespace Dovs.WordPressAutoKit.Services
 {

--- a/src/app/Dovs.WordPressAutoKit/Services/UserManagementService.cs
+++ b/src/app/Dovs.WordPressAutoKit/Services/UserManagementService.cs
@@ -1,6 +1,4 @@
 ﻿using Dovs.WordPressAutoKit.Interfaces;
-using Dovs.FileSystemInteractor.Interfaces;
-using Dovs.FileSystemInteractor.Services;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
 using Dovs.WordPressAutoKit.Common;


### PR DESCRIPTION
Refactor `GetAdminUserName` method to use comma-separated parameters instead of multi-parameters.